### PR TITLE
docs: course search: link to docs site instead of old wiki

### DIFF
--- a/source/community/release_notes/redwood/dev_op_release_notes.rst
+++ b/source/community/release_notes/redwood/dev_op_release_notes.rst
@@ -76,8 +76,7 @@ to enable those features which need configuration are as follows.
 Enabling Studio Course Search
 =============================
 
--  The Redwood release includes the `Studio Course Search [BETA]
-   <https://openedx.atlassian.net/wiki/spaces/OEPM/pages/4247257093/BETA+Course+Search+-+Product+Release+Notes>`_,
+-  The Redwood release includes the :doc:`/community/release_notes/redwood/course_search`,
    which is disabled by default as it depends on a new search engine,
    Meilisearch. We encourage operators to install Meilisearch, test out this
    feature, and give us feedback on the viability of using Meilisearch as a


### PR DESCRIPTION
Just updating a link since this page currently links to [a wiki page](https://openedx.atlassian.net/wiki/spaces/OEPM/pages/4247257093/BETA+Course+Search+-+Product+Release+Notes) which then in turn links to the docs.

![Screenshot 2024-08-06 at 10 52 43 AM](https://github.com/user-attachments/assets/595c5295-12ad-4b98-866d-a38ad130d744)
